### PR TITLE
support macos & fix warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ all : $(NAME)
 
 $(NAME) : $(OBJS)
 	@echo [LD] Linking $@
-	@$(CC) $(LDFLAGS) $(LIBDIRS) -Wl,--cref,-Map=$@.map $^ -o $@ $(LIBS)
+	@$(CC) $(LDFLAGS) $(LIBDIRS) -Wl $^ -o $@ $(LIBS)
 
 $(SOBJS) : %.o : %.S
 	@echo [AS] $<
@@ -73,4 +73,4 @@ install:
 	install -Dm0644 LICENSE /usr/share/licenses/xfel/LICENSE
 
 clean:
-	@$(RM) $(DEPS) $(OBJS) $(NAME).map $(NAME).exe $(NAME) *~
+	@$(RM) $(DEPS) $(OBJS) $(NAME).exe $(NAME) *~

--- a/main.c
+++ b/main.c
@@ -240,7 +240,7 @@ int main(int argc, char * argv[])
 		if(argc == 2)
 		{
 			uint32_t addr = strtoul(argv[0], NULL, 0);
-			size_t len;
+			uint64_t len;
 			void * buf = file_load(argv[1], &len);
 			if(buf)
 			{

--- a/x.h
+++ b/x.h
@@ -10,6 +10,8 @@ extern "C" {
 #endif
 #if defined(__linux__) || defined(__CYGWIN__)
 # include <endian.h>
+#elif defined(__MACH__)
+# include <sys/types.h>
 #elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 # include <sys/endian.h>
 #elif defined(__WINDOWS__)


### PR DESCRIPTION
如果--cref,-Map=$@.map只是为了开发调试的话，就去掉吧，macos的ld是llvm的，不支持这俩参数