### PR TITLE
Disable autosuspend on FEL devices

### DIFF
--- a/99-xfel.rules
+++ b/99-xfel.rules
@@ -3,3 +3,5 @@
 # with the command "sudo udevadm control --reload"
 
 ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1f3a", ATTRS{idProduct}=="efe8", MODE="666", GROUP="plugdev"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1f3a", ATTRS{idProduct}=="efe8", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"
+


### PR DESCRIPTION
Linux may sometimes try to suspend sunxi fel, and fail to resume them, leading to a USB reset when trying to do libusb_open, and libusb will fail. This commit disables autosuspend feature of all connected FEL devices by a udev rule.