### PR TITLE
Add GD5F1GQ5UExxG flash support

### DIFF
--- a/main.c
+++ b/main.c
@@ -134,7 +134,7 @@ int main(int argc, char * argv[])
 	}
 	if(!ctx.chip)
 	{
-		printf("WARNNING: Not yet support this device\r\n");
+		printf("WARNING: Not yet support this device\r\n");
 		printf("%.8s soc=0x%08x 0x%08x ver=0x%04x 0x%02x 0x%02x scratchpad=0x%08x\r\n",
 			ctx.version.magic, ctx.version.id, ctx.version.firmware,
 			ctx.version.protocol, ctx.version.dflag, ctx.version.dlength, ctx.version.scratchpad);
@@ -284,7 +284,7 @@ int main(int argc, char * argv[])
 		argc -= 2;
 		argv += 2;
 		if(fel_chip_ddr(&ctx, (argc == 1) ? argv[0] : NULL))
-			printf("Initial ddr controller sucessed\r\n");
+			printf("Initial ddr controller succeeded\r\n");
 		else
 			printf("Failed to initial ddr controller\r\n");
 	}

--- a/spinand.c
+++ b/spinand.c
@@ -48,6 +48,7 @@ static const struct spinand_info_t spinand_infos[] = {
 
 	/* Gigadevice */
 	{ "GD5F1GQ4UAWxx",   SPINAND_ID(0xc8, 0x10),       2048,  64,  64, 1024, 1, 1 },
+	{ "GD5F1GQ5UExxG",   SPINAND_ID(0xc8, 0x51),       2048, 128,  64, 1024, 1, 1 },
 	{ "GD5F1GQ4UExIG",   SPINAND_ID(0xc8, 0xd1),       2048, 128,  64, 1024, 1, 1 },
 	{ "GD5F1GQ4UExxH",   SPINAND_ID(0xc8, 0xd9),       2048,  64,  64, 1024, 1, 1 },
 	{ "GD5F1GQ4xAYIG",   SPINAND_ID(0xc8, 0xf1),       2048,  64,  64, 1024, 1, 1 },
@@ -138,6 +139,7 @@ static const struct spinand_info_t spinand_infos[] = {
 	{ "EM73E044SNE",     SPINAND_ID(0xd5, 0x0e),       4096, 256,  64, 4096, 1, 1 },
 	{ "EM73C044SNG",     SPINAND_ID(0xd5, 0x0c),       2048, 120,  64, 1024, 1, 1 },
 	{ "EM73D044VCN",     SPINAND_ID(0xd5, 0x0f),       2048,  64,  64, 2048, 1, 1 },
+
 
 	/* Elnec */
 	{ "FM35Q1GA",        SPINAND_ID(0xe5, 0x71),       2048,  64,  64, 1024, 1, 1 },


### PR DESCRIPTION
This PR adds support about GD5F1GQ5UEx, which is used in mango pi R3.

Below is the test result,
```
$ xfel spinand
Found spi nand flash 'GD5F1GQ5UEx' with 134217728 bytes
```