### PR TITLE
修正擦除范围过大的BUG。

### DIFF
--- a/spinor.c
+++ b/spinor.c
@@ -913,7 +913,8 @@ int spinor_write(struct xfel_ctx_t * ctx, uint64_t addr, void * buf, uint64_t le
 			return 0;
 		emask = esize - 1;
 		base = addr & ~emask;
-		cnt = ((addr & emask) + len + esize) & ~emask;
+		cnt = (addr == base)?0:esize;
+		cnt += ((len + emask) & ~emask);
 		progress_start(&p, cnt);
 		while(cnt > 0)
 		{


### PR DESCRIPTION
```patch
-		cnt = ((addr & emask) + len + esize) & ~emask;
+		cnt = (addr == base)?0:esize;
+		cnt += (len + emask) & ~emask;
```
原来的擦除数量计算中，直接加了esize，所以每次都多擦了4K。
在全片烧写时不会有影响，但只烧写其中一小块时，会误擦后面4K。

当不对齐时，分别向下和向上取整就行了，这样当不对齐时，最多只会擦除掉本扇区，不会影响其它扇区。