### PR TITLE
Add an uninstall section to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,5 +73,11 @@ install:
 	install -Dm0644 LICENSE /usr/share/licenses/xfel/LICENSE
 	udevadm control --reload
 
+uninstall:
+	rm -f /usr/local/bin/xfel
+	rm -f /etc/udev/rules.d/99-xfel.rules
+	rm -f /usr/share/licenses/xfel/LICENSE
+	udevadm control --reload
+
 clean:
 	@$(RM) $(DEPS) $(OBJS) $(NAME).exe $(NAME) *~


### PR DESCRIPTION
It is common to provide the user with a `make uninstall` option in the Makefile for a program.
This PR adds an `uninstall` option that removes all of the files that xfel installs with the `install` option and then reloads the udev rules.