### PR TITLE
Makefile: remove udevadm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,11 @@ install:
 	install -Dm0755 xfel /usr/local/bin/xfel
 	install -Dm0644 99-xfel.rules /etc/udev/rules.d/99-xfel.rules
 	install -Dm0644 LICENSE /usr/share/licenses/xfel/LICENSE
-	udevadm control --reload
 
 uninstall:
 	rm -f /usr/local/bin/xfel
 	rm -f /etc/udev/rules.d/99-xfel.rules
 	rm -f /usr/share/licenses/xfel/LICENSE
-	udevadm control --reload
 
 clean:
 	@$(RM) $(DEPS) $(OBJS) $(NAME).exe $(NAME) *~


### PR DESCRIPTION
udevadm是否执行应该由用户或系统决定，不应该写在Makefile里面