### PR TITLE
修正SPI NAND擦写问题

### DIFF
--- a/spinand.c
+++ b/spinand.c
@@ -154,6 +154,7 @@ static const struct spinand_info_t spinand_infos[] = {
 	/* Heyang */
 	{ "HYF1GQ4U",        SPINAND_ID(0xc9, 0x51),       2048, 128,  64, 1024, 1, 1 },
 	{ "HYF2GQ4U",        SPINAND_ID(0xc9, 0x52),       2048, 128,  64, 2048, 1, 1 },
+	{ "HYF4GQ4U",        SPINAND_ID(0xc9, 0x54),       2048, 128,  64, 4096, 1, 1 },
 };
 
 static inline int spinand_info(struct xfel_ctx_t * ctx, struct spinand_pdata_t * pdat)

--- a/spinand.c
+++ b/spinand.c
@@ -400,6 +400,9 @@ static void spinand_helper_write(struct xfel_ctx_t * ctx, struct spinand_pdata_t
 				addr += n;
 				buf += n;
 				count -= n;
+
+				if(!count)
+					break;
 			}
 			cbuf[clen++] = SPI_CMD_END;
 			fel_write(ctx, pdat->swapbuf, txbuf, txlen);


### PR DESCRIPTION
1、增加HYF4GQ4U支持
2、避免HYF4GQ4U擦写错误