### PR TITLE
修正USB设备检测问题

### DIFF
--- a/fel.c
+++ b/fel.c
@@ -185,6 +185,10 @@ int fel_init(struct xfel_ctx_t * ctx)
 		const struct libusb_interface * iface;
 		const struct libusb_interface_descriptor * setting;
 		const struct libusb_endpoint_descriptor * ep;
+
+		if(libusb_kernel_driver_active(ctx->hdl, 0))
+			libusb_detach_kernel_driver(ctx->hdl, 0);
+
 		if(libusb_claim_interface(ctx->hdl, 0) == 0)
 		{
 			if(libusb_get_active_config_descriptor(libusb_get_device(ctx->hdl), &config) == 0)

--- a/main.c
+++ b/main.c
@@ -128,7 +128,7 @@ static void usage(void)
 
 int main(int argc, char * argv[])
 {
-	struct xfel_ctx_t ctx;
+	struct xfel_ctx_t ctx = { 0 };
     libusb_context *context = NULL;
 
 


### PR DESCRIPTION
1、避免libusb未初始化指针崩溃问题
2、避免livesuit驱动设备占用问题