### PR TITLE
update ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ RM			:= rm -fr
 ASFLAGS		:= -g -ggdb -Wall -O3
 CFLAGS		:= -g -ggdb -Wall -O3
 CXXFLAGS	:= -g -ggdb -Wall -O3
-LDFLAGS		:=
+LDFLAGS		:= -Wl,-z,relro -Wl,-z,now -Wl,-z,shstk
 ARFLAGS		:= -rcs
 MCFLAGS		:=
 


### PR DESCRIPTION
arch 下 namcap 检测有相关警告提示，更新修复
相关警告
```bash
.....
installing namcap...
Checking PKGBUILD
Checking xfel-git-1.0.1.r41.g815dac9-1-x86_64.pkg.tar.zst
xfel-git W: ELF file ('usr/bin/xfel') lacks FULL RELRO, check LDFLAGS.
xfel-git W: ELF file ('usr/bin/xfel') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
Checking xfel-git-debug-1.0.1.r41.g815dac9-1-x86_64.pkg.tar.zst
==> Running checkpkg
...
```

更新 `ldflags` 后

```bash
...
installing namcap...
Checking PKGBUILD
Checking xfel-git-1.0.1.r41.g815dac9-1-x86_64.pkg.tar.zst
Checking xfel-git-debug-1.0.1.r41.g815dac9-1-x86_64.pkg.tar.zst
==> Running checkpkg
...
```