### PR TITLE
main: fix incorrect grammar in error message

### DIFF
--- a/main.c
+++ b/main.c
@@ -79,7 +79,7 @@ int main(int argc, char * argv[])
 
 	if(!fel_init(&ctx))
 	{
-		printf("ERROR: Can't found any FEL device\r\n");
+		printf("ERROR: No FEL device found!\r\n");
 		if(ctx.hdl)
 			libusb_close(ctx.hdl);
 		libusb_exit(NULL);


### PR DESCRIPTION
The phrase "Can't **found** any FEL device" is grammatically incorrect. "Can't **find** any FEL device" is correct, but I suggest using "No FEL device found!" as it might be more concise and clear.
